### PR TITLE
fix GetBits returns large byte array if read size / 8 == 0

### DIFF
--- a/pkg/bit/gobit.go
+++ b/pkg/bit/gobit.go
@@ -171,7 +171,7 @@ func GetBits(bytes []byte, off Offset, bitSize uint64) (ret []byte, err error) {
 	if bitSize%8 > 0 {
 		retSize = bitSize/8 + 1
 	} else {
-		retSize = bitSize
+		retSize = bitSize / 8
 	}
 	ret = make([]byte, retSize)
 

--- a/pkg/bit/gobit_test.go
+++ b/pkg/bit/gobit_test.go
@@ -348,6 +348,30 @@ func TestSetBits(t *testing.T) {
 	}
 }
 
+func TestGetBitsRetSize(t *testing.T) {
+	type testcase struct {
+		name    string
+		off     Offset
+		bitsize uint64
+		retsize int
+	}
+
+	cases := []testcase{
+		{"bitsize 7", Offset{Byte: 0, Bit: 0}, 7, 1},
+		{"bitsize 8", Offset{Byte: 0, Bit: 0}, 8, 1},
+	}
+
+	for _, v := range cases {
+		ret, err := GetBits([]byte{0xff, 0xff, 0xff, 0xff}, v.off, v.bitsize)
+		if err != nil {
+			t.Errorf("%s: Error %s", v.name, err)
+		}
+		if len(ret) != v.retsize {
+			t.Errorf("%s: mismatch. given %d. expected %d", v.name, len(ret), v.retsize)
+		}
+	}
+}
+
 func BenchmarkGetBits(b *testing.B) {
 	off := Offset{0, 6}
 	b.ResetTimer()


### PR DESCRIPTION
`GetBits` returns large byte array. If read size is divisible by 8.